### PR TITLE
update gatsby-node to current gatsby-starter-blog/gatsby-node.js - fi…

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,30 +1,31 @@
-const _ = require("lodash")
-const Promise = require("bluebird")
-const path = require("path")
-const select = require(`unist-util-select`)
-const fs = require(`fs-extra`)
+const _ = require('lodash')
+const Promise = require('bluebird')
+const path = require('path')
+const { createFilePath } = require('gatsby-source-filesystem')
 
 exports.createPages = ({ graphql, boundActionCreators }) => {
   const { createPage } = boundActionCreators
 
   return new Promise((resolve, reject) => {
-    const pages = []
-    const blogPost = path.resolve("./src/templates/blog-post.js")
+    const blogPost = path.resolve('./src/templates/blog-post.js')
     resolve(
       graphql(
         `
-      {
-        allMarkdownRemark(limit: 1000) {
-          edges {
-            node {
-              frontmatter {
-                path
+          {
+            allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }, limit: 1000) {
+              edges {
+                node {
+                  fields {
+                    slug
+                  }
+                  frontmatter {
+                    title
+                  }
+                }
               }
             }
           }
-        }
-      }
-    `
+        `
       ).then(result => {
         if (result.errors) {
           console.log(result.errors)
@@ -32,16 +33,36 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         }
 
         // Create blog posts pages.
-        _.each(result.data.allMarkdownRemark.edges, edge => {
+        const posts = result.data.allMarkdownRemark.edges;
+
+        _.each(posts, (post, index) => {
+          const previous = index === posts.length - 1 ? null : posts[index + 1].node;
+          const next = index === 0 ? null : posts[index - 1].node;
+
           createPage({
-            path: edge.node.frontmatter.path,
+            path: post.node.fields.slug,
             component: blogPost,
             context: {
-              path: edge.node.frontmatter.path,
+              slug: post.node.fields.slug,
+              previous,
+              next,
             },
           })
         })
       })
     )
   })
+}
+
+exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
+  const { createNodeField } = boundActionCreators
+
+  if (node.internal.type === `MarkdownRemark`) {
+    const value = createFilePath({ node, getNode })
+    createNodeField({
+      name: `slug`,
+      node,
+      value,
+    })
+  }
 }

--- a/src/pages/2015-05-01-hello-world/index.md
+++ b/src/pages/2015-05-01-hello-world/index.md
@@ -1,7 +1,6 @@
 ---
 title: Hello World
 date: "2015-05-01T22:12:03.284Z"
-path: "/hello-world/"
 ---
 
 This is my first post on my new fake blog! How exciting!

--- a/src/pages/2015-05-06-my-second-post/index.md
+++ b/src/pages/2015-05-06-my-second-post/index.md
@@ -1,7 +1,6 @@
 ---
 title: My Second Post!
 date: "2015-05-06T23:46:37.121Z"
-path: "/my-second-post/"
 ---
 
 Wow! I love blogging so much already.

--- a/src/pages/2015-05-28-hi-folks/index.md
+++ b/src/pages/2015-05-28-hi-folks/index.md
@@ -1,7 +1,6 @@
 ---
 title: New Beginnings
 date: "2015-05-28T22:40:32.169Z"
-path: "/hi-folks/"
 ---
 
 Far far away, behind the word mountains, far from the countries Vokalia

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,31 +12,25 @@ class BlogIndex extends React.Component {
 
     return (
       <div>
-        <Helmet title={get(this, 'props.data.site.siteMetadata.title')} />
+        <Helmet title={siteTitle} />
         <Bio />
-        {posts.map(post => {
-          if (post.node.path !== '/404/') {
-            const title = get(post, 'node.frontmatter.title') || post.node.path
-            return (
-              <div key={post.node.frontmatter.path}>
-                <h3>
-                  <Link to={post.node.frontmatter.path} >
-                    {post.node.frontmatter.title}
-                  </Link>
-                </h3>
-                <small>{post.node.frontmatter.date}</small>
-                <p dangerouslySetInnerHTML={{ __html: post.node.excerpt }} />
-              </div>
-            )
-          }
+        {posts.map(({ node }) => {
+          const title = get(node, 'frontmatter.title') || node.fields.slug
+          return (
+            <div key={node.fields.slug}>
+              <h3>
+                <Link style={{ boxShadow: 'none' }} to={node.fields.slug}>
+                  {title}
+                </Link>
+              </h3>
+              <small>{node.frontmatter.date}</small>
+              <p dangerouslySetInnerHTML={{ __html: node.excerpt }} />
+            </div>
+          )
         })}
       </div>
     )
   }
-}
-
-BlogIndex.propTypes = {
-  route: React.PropTypes.object,
 }
 
 export default BlogIndex
@@ -52,11 +46,11 @@ export const pageQuery = graphql`
       edges {
         node {
           excerpt
-          frontmatter {
-            path
-            date(formatString: "DD MMMM, YYYY")
+          fields {
+            slug
           }
           frontmatter {
+            date(formatString: "DD MMMM, YYYY")
             title
           }
         }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -9,17 +9,34 @@ class BlogPostTemplate extends React.Component {
   render() {
     const post = this.props.data.markdownRemark
     const siteTitle = get(this.props, 'data.site.siteMetadata.title')
+    const { previous, next } = this.props.pathContext
 
     return (
       <div>
         <Helmet title={`${post.frontmatter.title} | ${siteTitle}`} />
         <h1>{post.frontmatter.title}</h1>
-        <p>
-          {post.frontmatter.date}
-        </p>
+        <p>{post.frontmatter.date}</p>
         <div dangerouslySetInnerHTML={{ __html: post.html }} />
         <hr />
         <Bio />
+
+        <ul>
+          {previous && (
+            <li>
+              <Link to={previous.fields.slug} rel="prev">
+                ← {previous.frontmatter.title}
+              </Link>
+            </li>
+          )}
+
+          {next && (
+            <li>
+              <Link to={next.fields.slug} rel="next">
+                {next.frontmatter.title} →
+              </Link>
+            </li>
+          )}
+        </ul>
       </div>
     )
   }
@@ -28,14 +45,14 @@ class BlogPostTemplate extends React.Component {
 export default BlogPostTemplate
 
 export const pageQuery = graphql`
-  query BlogPostByPath($path: String!) {
+  query BlogPostBySlug($slug: String!) {
     site {
       siteMetadata {
         title
         author
       }
     }
-    markdownRemark(frontmatter: { path: { eq: $path } }) {
+    markdownRemark(fields: { slug: { eq: $slug } }) {
       id
       html
       frontmatter {


### PR DESCRIPTION
…xes "path" warning when starting gatsby develop, resolves issue #2 in my testing

@noahg 
I was receiving the same "path" errors as @singingwolfboy in issue #2.
I copied the gatsby-node.js from the Kyle's gatsby-starter-blog and it cleared up the issues.

The only reason there are so many line changes is because of stricter style in the `gatsby-starter-blog` (lots of double quotes and backticks replaced with single quotes) and the removal of `fs`, which was no longer necessary. 

To test I ran the following:
```bash
gatsby new test-my-starter https://github.com/HyperSprite/gatsby-starter-blog-no-styles
cd test-my-starter
gatsby develop
```
Completed starting and localhost:8000 worked as it should.

Let me know if you have any questions,
Chris
